### PR TITLE
use pre-increment for non-primitive types

### DIFF
--- a/src/session.cc
+++ b/src/session.cc
@@ -69,7 +69,7 @@ void Session::ChannelClosedCallback (Channel *channel, void *userData) {
         std::cout << "Found and removed channel from list\n";
       break;
     }
-    it++;
+    ++it;
   }
 
   /*


### PR DESCRIPTION
Pre-increment/decrement can be more efficient than post-increment/decrement. Post-increment/decrement usually involves keeping a copy of the previous value around and adds a little extra code.

Issue(s) found via [cppcheck](http://cppcheck.sourceforge.net/).
