### PR TITLE
added support for windowchange events

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -8,7 +8,7 @@ function Channel (server, channel) {
   channel.onMessage = function (message) {
     if (this._server._options.debug)
       console.log('channel message', message)
-    if (message.subtype && /^(exec|subsystem|shell|pty|env)$/.test(message.subtype))
+    if (message.subtype && /^(exec|subsystem|shell|pty|env|windowchange)$/.test(message.subtype))
       return this.emit(message.subtype, message)
     // else handle default.. probably should pass this on
     message.replyDefault()

--- a/src/message.cc
+++ b/src/message.cc
@@ -178,6 +178,11 @@ v8::Handle<v8::Object> Message::NewInstance (
       const char *term = ssh_message_channel_request_pty_term(message);
       if (term)
         instance->Set(NanSymbol("ptyTerm"), v8::String::New(term));
+    } else if (subtype == SSH_CHANNEL_REQUEST_WINDOW_CHANGE) {
+      instance->Set(NanSymbol("ptyWidth"),
+          v8::Integer::New(ssh_message_channel_request_pty_width(message)));
+      instance->Set(NanSymbol("ptyHeight"),
+          v8::Integer::New(ssh_message_channel_request_pty_height(message)));
     }
   }
 


### PR DESCRIPTION
Added 'windowchange' to list of events to emit - message includes new values for ptyWidth and ptyHeight. Updated term.js example to use it.
