### PR TITLE
Disable poller and free Session when client disconnects

### DIFF
--- a/src/session.cc
+++ b/src/session.cc
@@ -190,6 +190,12 @@ void Session::SocketPollCallback (uv_poll_t* handle, int status, int events) {
 
   if (NSSH_DEBUG)
     std::cout << "Channel Data: " << (channelData ? "yes" : "no") << std::endl;
+
+  if (ssh_get_status(s->session) & SSH_CLOSED_ERROR) {
+    if (NSSH_DEBUG)
+      std::cout << "session status is SSH_CLOSED_ERROR, closing2\n";
+    return s->Close();
+  }
 }
 
 Session::Session () {
@@ -205,7 +211,7 @@ Session::~Session () {
 void Session::Close () {
   active = false;
   uv_poll_stop(poll_handle);
-  //delete poll_handle;
+  delete poll_handle;
   ssh_set_callbacks(session, 0);
   ssh_set_message_callback(session, 0, 0);
   //TODO: investigate whether this is needed in some way, it doesn't


### PR DESCRIPTION
A client closing its socket immediately after sending some data may leave
the server with a closed socket that still has its uv poller in place,
because Session::Close() may never get called in that case. This is an error
condition that causes uv to try and poll on a closed socket and also triggers
an assertion like following as soon as the fd is reused, e.g. by a new client:

```
node: ../deps/uv/src/unix/core.c:724:
    uv__io_stop: Assertion `loop->watchers[w->fd] == w' failed.
```
