### PR TITLE
Fix building on OS X Yosemite

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -30,6 +30,12 @@
                     '-lssl'
                   , '-lcrypto'
                 ]
+              , 'xcode_settings': {
+                    'OTHER_CPLUSPLUSFLAGS': ['-std=c++11', '-stdlib=libc++']
+                  , 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
+                  , 'MACOSX_DEPLOYMENT_TARGET': '10.8'
+                }
+              , 'defines': ['HAVE_NTOHLL']
             }]
           , ['OS == "win"', {
               'conditions': [

--- a/deps/libssh.gyp
+++ b/deps/libssh.gyp
@@ -51,6 +51,12 @@
                    'include-osx/'
                ]
            }
+         , 'xcode_settings': {
+               'OTHER_CPLUSPLUSFLAGS': ['-std=c++11', '-stdlib=libc++']
+             , 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
+             , 'MACOSX_DEPLOYMENT_TARGET': '10.8'
+           }
+         , 'defines': ['HAVE_NTOHLL']
        }]
      , ['OS == "win"', {
            'include_dirs': [


### PR DESCRIPTION
Some C++ stuff changed with the Yosemite update; this should hopefully resolve those with minimal hassle and without breaking older on older Mac OS X versions.